### PR TITLE
【バグ修正】出力画像がディスプレイの拡大率に影響される問題を修正。

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
-/* ダミー画像ジェネレーター（GitHub Pages 用・クライアント完結） */
+/* ダミー画像ジェネレーター（GitHub Pages 用・クライアント完結）
+   ※ 出力画像の実寸がOSスケーリングに影響されないよう、DPRは使用しません（常に @1x）。 */
 (() => {
     const $ = (sel) => document.querySelector(sel);
 
@@ -29,7 +30,6 @@
     };
 
     let currentObjectUrl = null; // SVG/PNGの一時URLを管理して解放
-    const DPR = Math.max(1, Math.min(3, window.devicePixelRatio || 1));
 
     // ---- utils ----
     const clamp = (n, min, max) => Math.min(max, Math.max(min, n));
@@ -53,12 +53,13 @@
     // ---- 描画（PNG: canvas） ----
     function drawPng({ w, h, bg, fg, text, fontFamily, radius, fontPx, autoFont }) {
         const cvs = el.canvas;
-        cvs.width = Math.round(w * DPR);
-        cvs.height = Math.round(h * DPR);
+
+        // ★ 出力サイズは要求通りのピクセル数に固定（DPR無視／常に@1x）
+        cvs.width = w;
+        cvs.height = h;
 
         const ctx = cvs.getContext("2d");
         ctx.save();
-        ctx.scale(DPR, DPR);
 
         // 角丸矩形
         const r = clamp(radius, 0, Math.min(w, h) / 2);
@@ -77,12 +78,11 @@
         ctx.textBaseline = "middle";
 
         // 長文のとき縮小
-        let scale = 1;
         let metrics = ctx.measureText(text);
         const pad = Math.max(8, fontSize * 0.4);
         const maxW = w - pad * 2;
         if (metrics.width > maxW) {
-            scale = maxW / metrics.width;
+            const scale = maxW / metrics.width;
             ctx.save();
             ctx.translate(w / 2, h / 2);
             ctx.scale(scale, scale);
@@ -93,6 +93,7 @@
         }
 
         ctx.restore();
+        // ★ この dataURL は w×h ちょうどのPNGになります
         return cvs.toDataURL("image/png");
     }
 

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,12 @@
 #preview {
     max-height: 60vh;
     background: #fff;
+
+    /* ▼ プレビューのにじみ軽減（出力は@1x固定のまま） */
+    image-rendering: -webkit-optimize-contrast;
+    /* Safari系 */
+    image-rendering: crisp-edges;
+    /* 対応ブラウザで輪郭をくっきり */
 }
 
 .card-header .small {


### PR DESCRIPTION
## 概要
display scaling（125%など）有効時に、生成されるPNG画像が指定より約1.25倍になる問題を修正しました。

## 変更内容
- app.js内のDPR（window.devicePixelRatio）を使用したスケーリング処理を削除
- 出力キャンバスを常に@1xのピクセルサイズで描画
- これによりOSのスケーリング設定に関わらず、w×hピクセルで正確に出力されます

## 動作確認
- Windows11 / Chrome125% で w=150, h=150 のPNGを生成 → 150×150 px で出力確認済み
- 通常スケール（100%）でも同様に動作

## 関連Issue
Close #1 
