### PR TITLE
【文書修正】READMEの構成を整理し、利用者・開発者向け情報を明確化

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,26 +23,30 @@ Webブラウザ上でダミー画像（プレースホルダー）を生成で�
 
 ---
 
-## 🛠 使い方
+## 🚀 使い方
 
-1. このリポジトリをクローン、または ZIP でダウンロードします。
+以下のURLを開くだけで利用できます。  
+👉 **[https://yourname.github.io/placeholder-generator/](https://yourname.github.io/placeholder-generator/)**
+
+ブラウザ上でサイズ・色・文字などを設定し、「プレビュー更新」をクリックしてください。  
+生成した画像はそのままダウンロード・コピー・共有できます。
+
+---
+
+## 🧑‍💻 開発環境構築
+
+機能を改造したい場合や、ローカルで検証したい場合は以下の手順でセットアップします。
+
+1. このリポジトリをクローン、または ZIP ダウンロードします。
 
    ```bash
    git clone https://github.com/yourname/placeholder-generator.git
    ```
 
-2. 以下の 3 ファイルを GitHub リポジトリのルートディレクトリに配置します。
+2. 任意のHTTPサーバを起動して `index.html` を開きます。  
+   例：VSCode拡張機能 **Live Server**
 
-   ```text
-   index.html
-   styles.css
-   app.js
-   ```
-
-3. **GitHub Pages** を **mainブランチ / root** に設定して有効化します。
-
-4. 公開された URL にアクセスし、フォームからサイズや色を設定して「プレビュー更新」をクリック。
-   そのまま画像を保存・コピー・共有できます。
+3. ブラウザで `http://localhost:ポート番号` にアクセスして動作を確認します。
 
 ---
 


### PR DESCRIPTION
## 概要

READMEの内容を整理し、一般ユーザーと開発者の双方にとってわかりやすい構成にしました。
特に「使い方」と「開発環境構築」を明確に分離し、GitHub Pages公開ツールとしての導線を改善しています。
併せて、ローカル開発時のポート番号に関する補足も追記しました。

##変更内容
- 「🛠 使い方」セクションを削除し、代わりに「🚀 使い方」と「🧑‍💻 開発環境構築」に分離
- 一般ユーザー向けに「公開URLを開くだけで利用可能」であることを明示
- 開発者向けにクローン手順とLive Server使用例を記載
- http://localhost:8000 の表記を汎用化
- 全体の文体と見出し構成を統一（ハイフン・全角記号・句読点の整備）

## 目的
- 一般ユーザーがREADMEを読んで即ツールを利用できるようにする
- 開発者がFork後の環境構築方法を迷わず実行できるようにする
- ドキュメントとしての統一感と可読性を高める

## 関連Issue
Close #3